### PR TITLE
twi: Remove start condition delay

### DIFF
--- a/simavr/sim/avr_twi.c
+++ b/simavr/sim/avr_twi.c
@@ -193,9 +193,9 @@ avr_twi_write(
 #endif
 		// generate a start condition
 		if (p->state & TWI_COND_START)
-			_avr_twi_delay_state(p, 3, TWI_REP_START);
+			_avr_twi_delay_state(p, 0, TWI_REP_START);
 		else
-			_avr_twi_delay_state(p, 3, TWI_START);
+			_avr_twi_delay_state(p, 0, TWI_START);
 		p->peer_addr = 0;
 		p->state = TWI_COND_START;
 	}


### PR DESCRIPTION
> This corrects a problem where a non-interrupt driven twi driver
>     functions on the target (m32) but not in simavr.
> This also fixes ../examples/board_i2ctest so that it functions as
>     expected.
